### PR TITLE
cmgd: changes to handle conversion of xpath to adapter

### DIFF
--- a/cmgd/cmgd_bcknd_adapter.h
+++ b/cmgd/cmgd_bcknd_adapter.h
@@ -25,6 +25,25 @@
 #include "cmgd/cmgd_defines.h"
 #include "lib/cmgd_bcknd_client.h"
 
+#define CMGD_FIND_ADAPTER_BY_INDEX(adapter_index)	\
+	cmgd_adaptr_ref[adapter_index]
+
+// List of adapter clients of CMGD
+#define CMGD_BCKND_CLIENT_INDEX_STATICD (1 << CMGD_BCKND_CLIENT_ID_STATICD)
+#define CMGD_BCKND_CLIENT_INDEX_BGPD (1 << CMGD_BCKND_CLIENT_ID_BGPD)
+
+// XPATH regular expression map index
+typedef enum cmgd_bcknd_xpath_regexp_id_ {
+	CMGD_BCKND_XPATH_REGEXP_ID_FILTER,
+	CMGD_BCKND_XPATH_REGEXP_ID_INTERFACE,
+	CMGD_BCKND_XPATH_REGEXP_ID_ROUTEMAP,
+	CMGD_BCKND_XPATH_REGEXP_ID_VRF,
+	CMGD_BCKND_XPATH_REGEXP_ID_ROUTING,
+	CMGD_BCKND_XPATH_REGEXP_ID_ROUTING_STATIC,
+	CMGD_BCKND_XPATH_REGEXP_ID_ROUTING_BGP,
+	CMGD_BCKND_XPATH_REGEXP_ID_ROUTEMAP_BGP,
+} cmgd_bcknd_xpath_regexp_id_t;
+
 typedef enum cmgd_bcknd_req_type_ {
         CMGD_BCKND_REQ_NONE = 0,
         CMGD_BCKND_REQ_CFG_VALIDATE,
@@ -32,6 +51,12 @@ typedef enum cmgd_bcknd_req_type_ {
         CMGD_BCKND_REQ_DATA_GET_ELEM,
         CMGD_BCKND_REQ_DATA_GET_NEXT
 } cmgd_bcknd_req_type_t;
+
+typedef struct cmgd_bcknd_xpath_map_ {
+	uint32_t xpath_regex_id;   // ID for easy access
+	const char *xpath_regexp;  // hierarchical expression
+	uint32_t bknd_client_ids;  // Stores list of adapter IDs
+} cmgd_bcknd_xpath_map_t;
 
 typedef struct cmgd_bcknd_cfgreq_ {
         cmgd_bcknd_req_type_t req_type;
@@ -97,6 +122,7 @@ typedef struct cmgd_bcknd_client_adapter_ {
 	/* Buffer of data waiting to be written to client. */
 	// struct buffer *wb;
 
+        int adapter_index;
         int refcount;
 
         struct cmgd_bcknd_adptr_list_item list_linkage;
@@ -105,6 +131,8 @@ typedef struct cmgd_bcknd_client_adapter_ {
 
 DECLARE_LIST(cmgd_bcknd_adptr_list, cmgd_bcknd_client_adapter_t, list_linkage);
 DECLARE_LIST(cmgd_trxn_badptr_list, cmgd_bcknd_client_adapter_t, trxn_list_linkage);
+
+extern cmgd_bcknd_client_adapter_t *cmgd_adaptr_ref[CMGD_BCKND_CLIENT_ID_MAX];
 
 extern int cmgd_bcknd_adapter_init(struct thread_master *tm);
 
@@ -137,4 +165,6 @@ extern int cmgd_bcknd_send_get_next_data_req(
 
 extern void cmgd_bcknd_adapter_status_write(struct vty *vty);
 
+extern void cmgd_bcknd_adaptr_ref_init(void);
+extern uint32_t cmgd_trxn_derive_adapters_for_xpath(const char *xpath);
 #endif /* _FRR_CMGD_BCKND_ADAPTER_H_ */

--- a/cmgd/cmgd_main.c
+++ b/cmgd/cmgd_main.c
@@ -43,6 +43,7 @@
 #include "ns.h"
 
 #include "cmgd/cmgd.h"
+#include "cmgd/cmgd_bcknd_adapter.h"
 
 #include "lib/routing_nb.h"
 #include "staticd/static_nb.h"
@@ -578,6 +579,7 @@ int main(int argc, char **argv)
 	/* must be called after fork() */
 	cmgd_gr_apply_running_config();
 #endif
+	cmgd_bcknd_adaptr_ref_init();
 	cmgd_pthreads_run();
 
 	frr_run(cm->master);

--- a/lib/cmgd_bcknd_client.c
+++ b/lib/cmgd_bcknd_client.c
@@ -37,6 +37,8 @@
 	zlog_err("%s: ERROR: " fmt , __func__, ##__VA_ARGS__)
 #endif /* REDIRECT_DEBUG_TO_STDERR */
 
+const char *cmgd_bcknd_client_names[] = {CMGD_BCKND_CLIENT_STATICD, CMGD_BCKND_CLIENT_BGPD};
+
 typedef struct cmgd_bcknd_client_ctxt_ {
 	int conn_fd;
 	struct thread_master *tm;

--- a/lib/cmgd_bcknd_client.h
+++ b/lib/cmgd_bcknd_client.h
@@ -46,9 +46,18 @@ extern "C" {
 #define CMGD_BCKND_MSG_MAX_LEN		        4096
 
 
+#define CMGD_BCKND_CLIENT_BGPD			"bgpd"
+#define CMGD_BCKND_CLIENT_STATICD		"staticd"
+
 /***************************************************************
  * Data-structures
  ***************************************************************/
+
+typedef enum cmgd_bcknd_client_id_ {
+        CMGD_BCKND_CLIENT_ID_STATICD = 0,
+        CMGD_BCKND_CLIENT_ID_BGPD,
+        CMGD_BCKND_CLIENT_ID_MAX
+} cmgd_bcknd_client_id_t;
 
 typedef struct cmgd_bcknd_msg_hdr_ {
 	uint16_t		marker;

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -1205,7 +1205,7 @@ static void static_cmgd_bcknd_client_connect(
 }
 
 static cmgd_bcknd_client_params_t cmgd_params = {
-	.name = "Staticd",
+	.name = CMGD_BCKND_CLIENT_STATICD,
 	.conn_retry_intvl_sec = 3,
 	.conn_notify_cb = static_cmgd_bcknd_client_connect
 };


### PR DESCRIPTION
Have implemented the changes to convert xpath string to
adapter list that can be used to dispath xpaths to specific
daemons or modules.

Signed-off-by: Abhinay Ramesh <rabhinay@vmware.com>