### PR TITLE
cmgd: fix cmgd startup crash issue

### DIFF
--- a/cmgd/cmgd_frntnd_adapter.c
+++ b/cmgd/cmgd_frntnd_adapter.c
@@ -210,6 +210,9 @@ static int cmgd_frntnd_adapter_send_msg(cmgd_frntnd_client_adapter_t *adptr,
 	uint8_t msg_buf[CMGD_FRNTND_MSG_MAX_LEN];
 	cmgd_frntnd_msg_t *msg;
 
+	if (adptr->conn_fd == 0)
+		return -1;
+
 	msg_size = cmgd__frntnd_message__get_packed_size(frntnd_msg);
 	msg_size += CMGD_FRNTND_MSG_HDR_LEN;
 	if (msg_size > sizeof(msg_buf)) {

--- a/lib/cmgd_bcknd_client.c
+++ b/lib/cmgd_bcknd_client.c
@@ -243,6 +243,9 @@ static int cmgd_bcknd_client_send_msg(cmgd_bcknd_client_ctxt_t *clnt_ctxt,
 	uint8_t msg_buf[CMGD_BCKND_MSG_MAX_LEN];
 	cmgd_bcknd_msg_t *msg;
 
+	if (clnt_ctxt->conn_fd == 0)
+		return -1;
+
 	msg_size = cmgd__bcknd_message__get_packed_size(bcknd_msg);
 	msg_size += CMGD_BCKND_MSG_HDR_LEN;
 	if (msg_size > sizeof(msg_buf)) {

--- a/lib/cmgd_frntnd_client.c
+++ b/lib/cmgd_frntnd_client.c
@@ -144,6 +144,9 @@ static int cmgd_frntnd_client_send_msg(cmgd_frntnd_client_ctxt_t *clnt_ctxt,
 	uint8_t msg_buf[CMGD_FRNTND_MSG_MAX_LEN];
 	cmgd_frntnd_msg_t *msg;
 
+	if (clnt_ctxt->conn_fd == 0)
+		return -1;
+
 	msg_size = cmgd__frntnd_message__get_packed_size(frntnd_msg);
 	msg_size += CMGD_FRNTND_MSG_HDR_LEN;
 	if (msg_size > sizeof(msg_buf)) {


### PR DESCRIPTION
When there is connection disconnect and if there is some message
to be sent over connection it fails due to fd reset.

Changes to stop send message when the fd is not valid.

Signed-off-by: Abhinay Ramesh <rabhinay@vmware.com>