### PR TITLE
cmgd: Tree not traversing for one child

### DIFF
--- a/cmgd/cmgd_db.c
+++ b/cmgd/cmgd_db.c
@@ -285,7 +285,7 @@ static int cmgd_walk_db_nodes(cmgd_db_ctxt_t *db_ctxt,
 		if (!childs_as_well)
 			continue;
 
-		if (set->count > 1) {
+		if (set->count >= 1) {
 			if (num_nodes)
 				num_found = num_left;
 


### PR DESCRIPTION
For a node with one child the traversal should carry on till we
reach the leaf node.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>