### PR TITLE
cmgd: fix crash for get-data  with certain xpaths

### DIFF
--- a/cmgd/cmgd_db.c
+++ b/cmgd/cmgd_db.c
@@ -385,6 +385,7 @@ int cmgd_db_lookup_data_nodes(
 		xpath += 2;
 
 	strncpy(base_xpath, xpath, sizeof(base_xpath));
+	remove_slash_at_the_end(base_xpath);
 
 	return (cmgd_walk_db_nodes(db_ctxt, base_xpath, NULL, NULL, NULL,
 			dxpaths, dnodes, nbnodes, num_nodes,
@@ -455,6 +456,8 @@ int cmgd_db_iter_data(
 	db_ctxt = (cmgd_db_ctxt_t *)db_hndl;
 	if (!db_ctxt)
 		return -1;
+
+	remove_slash_at_the_end(base_xpath);
 
 	strncpy(xpath, base_xpath, sizeof(xpath));
 

--- a/cmgd/cmgd_db.h
+++ b/cmgd/cmgd_db.h
@@ -41,6 +41,9 @@
 #define FOREACH_CMGD_DB_ID(id)			                \
 	for ((id) = CMGD_DB_NONE; (id) < CMGD_DB_MAX_ID; (id)++)
 
+#define remove_slash_at_the_end(str)					\
+	if (str[strlen(str) - 1] == '/') str[strlen(str) - 1] = '\0'
+
 typedef uintptr_t cmgd_db_hndl_t;
 
 typedef void (*cmgd_db_node_iter_fn)(cmgd_db_hndl_t db_hndl, 


### PR DESCRIPTION
Xpaths with trailing slash '/' crashes at yang_done get.

Signed-off-by: Yash Ranjan <ranjany@vmware.com>