### PR TITLE
cmgd: fix show adapter details cmd help string.

### DIFF
--- a/cmgd/cmgd_vty.c
+++ b/cmgd/cmgd_vty.c
@@ -190,7 +190,8 @@ DEFPY(show_cmgd_frntnd_adapter_detail,
 	SHOW_STR
 	CMGD_STR
 	CMGD_FRNTND_ADPTR_STR
-	"Display all Frontend Adapters\n")
+	"Display all Frontend Adapters\n"
+	"Details of commit stats\n")
 {
 	cmgd_frntnd_adapter_status_write(vty, true);
 


### PR DESCRIPTION
Help string was missing.

Signed-off-by: Abhinay Ramesh <rabhinay@vmware.com>