### PR TITLE
cmgd: Candidate DB and Running DB should be synced at startup

### DIFF
--- a/cmgd/cmgd_db.c
+++ b/cmgd/cmgd_db.c
@@ -176,11 +176,10 @@ int cmgd_db_init(struct cmgd_master *cm)
 	}
 
 	running.root.cfg_root = running_config;
-	// running.root.cfg_root = nb_config_new(NULL);
 	running.config_db = true;
 	running.db_id = CMGD_DB_RUNNING;
 
-	candidate.root.cfg_root = nb_config_new(NULL);
+	candidate.root.cfg_root = nb_config_dup(running.root.cfg_root);
 	candidate.config_db = true;
 	candidate.db_id = CMGD_DB_CANDIDATE;
 


### PR DESCRIPTION
Signed-off-by: Yash Ranjan <ranjany@vmware.com>