### PR TITLE
cmgd: change to improve 'vtysh -f' performance with commit

### DIFF
--- a/lib/lib_vty.c
+++ b/lib/lib_vty.c
@@ -260,6 +260,9 @@ DEFUN_HIDDEN (end_config,
 
 	zlog_info("Configuration Read in Took: %s", readin_time_str);
 
+	if(vty_cmgd_frntnd_enabled())
+		vty_cmgd_send_commit_config(vty, false, false);
+
 	if (callback.end_config)
 		(*callback.end_config)();
 

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3424,7 +3424,8 @@ int vty_cmgd_send_config_data(struct vty *vty)
 			cmgd_lib_hndl, vty->cmgd_session_id,
 			vty->cmgd_req_id, CMGD_DB_CANDIDATE, cfgreq, cnt,
 			frr_get_cli_mode() == FRR_CLI_CLASSIC ?
-			true : false, CMGD_DB_RUNNING) != CMGD_SUCCESS) {
+			((vty->pending_allowed) ? false : true) : false,
+			CMGD_DB_RUNNING) != CMGD_SUCCESS) {
 			zlog_err("Failed to send %d Config Xpaths to CMGD!!",
 				(int) indx);
 			return -1;


### PR DESCRIPTION
When vtysh -f option is used to load config, at the bcknd
changes are batched and ensured that commit happens faster.
Same logic is used for cmgd infra.

Signed-off-by: Abhinay Ramesh <rabhinay@vmware.com>