### PR TITLE
cmgd: Throw a warning instead of error when reading empty config

### DIFF
--- a/cmgd/cmgd_trxn.c
+++ b/cmgd/cmgd_trxn.c
@@ -1172,7 +1172,7 @@ static int cmgd_trxn_prepare_config(cmgd_trxn_ctxt_t *trxn)
 		 * This means there's no changes to commit whatsoever 
 		 * is the source of the changes in config.
 		 */
-		(void) cmgd_trxn_send_commit_cfg_reply(trxn, false,
+		(void) cmgd_trxn_send_commit_cfg_reply(trxn, true,
 			"No changes found to be committed!");
 		ret = -1;
 		goto cmgd_trxn_prepare_config_done;

--- a/lib/vty.c
+++ b/lib/vty.c
@@ -3318,6 +3318,8 @@ static void vty_cmgd_commit_config_result_notified(
 	} else {
 		zlog_err("COMMIT_CONFIG request for client 0x%lx req-id %lu was successfull!",
 			client_id, req_id);
+		if (errmsg_if_any)
+			vty_out(vty, "CMGD: %s\n", errmsg_if_any);
 	}
 
 	vty_cmgd_resume_response(vty, success);


### PR DESCRIPTION
Signed-off-by: Yash Ranjan <ranjany@vmware.com>