### PR TITLE
mgmtd: Add Staticd as the first backend client for the MGMT Framework

### DIFF
--- a/debian/frr.install
+++ b/debian/frr.install
@@ -7,6 +7,7 @@ usr/bin/vtysh
 usr/lib/*/frr/libfrr.*
 usr/lib/*/frr/libfrrcares.*
 usr/lib/*/frr/libfrrospfapiclient.*
+usr/lib/*/frr/libmgmt_bcknd_nb.*
 usr/lib/*/frr/modules/bgpd_bmp.so
 usr/lib/*/frr/modules/dplane_fpm_nl.so
 usr/lib/*/frr/modules/zebra_cumulus_mlag.so

--- a/mgmtd/mgmt_main.c
+++ b/mgmtd/mgmt_main.c
@@ -232,7 +232,7 @@ static void mgmt_vrf_terminate(void)
  */
 static const struct frr_yang_module_info *const mgmt_yang_modules[] = {
 	&frr_filter_info,  &frr_interface_info, &frr_route_map_info,
-	&frr_routing_info, &frr_vrf_info,
+	&frr_routing_info, &frr_vrf_info,       &frr_staticd_info,
 };
 
 FRR_DAEMON_INFO(mgmtd, MGMTD, .vty_port = MGMTD_VTY_PORT,

--- a/mgmtd/mgmt_vty.c
+++ b/mgmtd/mgmt_vty.c
@@ -55,6 +55,16 @@
 #endif
 
 /*
+ * Declare prototypes for command initialization routines defined by
+ * backend components that have been moved to new MGMTD infra here
+ * one by one. These are supposed to be compiled into
+ * mgmt/ibmgmt_bcknd_nb.la first and then called from mgmt_vty_init()
+ * below to load all backend client command handlers on MGMTd
+ * process context.
+ */
+extern void static_vty_init(void);
+
+/*
  * mgmt_enqueue_nb_command
  *
  * Add a config command from VTYSH for further processing.
@@ -733,6 +743,14 @@ DEFPY(debug_mgmt_all,
 
 void mgmt_vty_init(void)
 {
+	/*
+	 * Initialize command handling from VTYSH connection.
+	 * Call command initialization routines defined by
+	 * backend components that are moved to new MGMTD infra
+	 * here one by one.
+	 */
+	static_vty_init();
+
 	install_node(&debug_node);
 
 	install_element(VIEW_NODE, &show_mgmt_bcknd_adapter_cmd);

--- a/mgmtd/subdir.am
+++ b/mgmtd/subdir.am
@@ -13,9 +13,24 @@ vtysh_daemons += mgmtd
 # man8 += $(MANBUILD)/frr-mgmtd.8
 # endif
 
+$(mgmtd_mgmtd_OBJECTS): yang/frr-staticd.yang.c
+CLEANFILES += yang/frr-staticd.yang.c
+
 clippy_scan += \
 	mgmtd/mgmt_vty.c \
 	# end
+
+lib_LTLIBRARIES += mgmtd/libmgmt_bcknd_nb.la
+nodist_mgmtd_libmgmt_bcknd_nb_la_SOURCES = \
+	yang/frr-staticd.yang.c \
+	staticd/static_vty.c \
+	staticd/static_nb.c \
+	staticd/static_nb_config.c \
+	# end
+mgmtd_libmgmt_bcknd_nb_la_CFLAGS = $(AM_CFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY -DINCLUDE_MGMTD_VALIDATE_ONLY
+mgmtd_libmgmt_bcknd_nb_la_CPPFLAGS = $(AM_CPPFLAGS) -DINCLUDE_MGMTD_CMDDEFS_ONLY -DINCLUDE_MGMTD_VALIDATE_ONLY
+mgmtd_libmgmt_bcknd_nb_la_LDFLAGS = -version-info 0:0:0
+mgmtd_libmgmt_bcknd_nb_la_LIBADD = lib/libfrr.la
 
 noinst_LIBRARIES += mgmtd/libmgmtd.a
 mgmtd_libmgmtd_a_SOURCES = \
@@ -49,3 +64,4 @@ mgmtd_mgmtd_SOURCES = \
 	# end
 mgmtd_mgmtd_CFLAGS = $(AM_CFLAGS) -I ./
 mgmtd_mgmtd_LDADD = mgmtd/libmgmtd.a lib/libfrr.la $(LIBCAP) $(LIBM) $(LIBYANG_LIBS) $(UST_LIBS)
+mgmtd_mgmtd_LDADD += mgmtd/libmgmt_bcknd_nb.la

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -78,6 +78,8 @@ static void sigint(void)
 {
 	zlog_notice("Terminating on signal");
 
+	static_mgmt_destroy();
+
 	static_vrf_terminate();
 
 	frr_fini();
@@ -159,6 +161,9 @@ int main(int argc, char **argv, char **envp)
 
 	static_zebra_init();
 	static_vty_init();
+
+	/* Initialize MGMT backend functionalities */
+	static_mgmt_init(master);
 
 	hook_register(routing_conf_event,
 		      routing_control_plane_protocols_name_validate);

--- a/staticd/static_nb.c
+++ b/staticd/static_nb.c
@@ -60,7 +60,9 @@ const struct frr_yang_module_info frr_staticd_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/path-list/frr-nexthops/nexthop",
 			.cbs = {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish,
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,
@@ -141,7 +143,9 @@ const struct frr_yang_module_info frr_staticd_info = {
 		{
 			.xpath = "/frr-routing:routing/control-plane-protocols/control-plane-protocol/frr-staticd:staticd/route-list/src-list/path-list/frr-nexthops/nexthop",
 			.cbs = {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 				.apply_finish = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_apply_finish,
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 				.create = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_create,
 				.destroy = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_path_list_frr_nexthops_nexthop_destroy,
 				.pre_validate = routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate,

--- a/staticd/static_nb_config.c
+++ b/staticd/static_nb_config.c
@@ -35,11 +35,13 @@
 
 static int static_path_list_create(struct nb_cb_create_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct route_node *rn;
 	struct static_path *pn;
+	uint8_t distance;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 	const struct lyd_node *vrf_dnode;
 	const char *vrf;
-	uint8_t distance;
 	uint32_t table_id;
 
 	switch (args->event) {
@@ -66,12 +68,17 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 	case NB_EV_ABORT:
 	case NB_EV_PREPARE:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		distance = yang_dnode_get_uint8(args->dnode, "./distance");
 		table_id = yang_dnode_get_uint32(args->dnode, "./table-id");
 		pn = static_add_path(rn, table_id, distance);
 		nb_running_set_entry(args->dnode, pn);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 
 	return NB_OK;
@@ -79,16 +86,22 @@ static int static_path_list_create(struct nb_cb_create_args *args)
 
 static int static_path_list_destroy(struct nb_cb_destroy_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_path *pn;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		pn = nb_running_unset_entry(args->dnode);
 		static_del_path(pn);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -97,17 +110,23 @@ static int static_path_list_destroy(struct nb_cb_destroy_args *args)
 
 static int static_path_list_tag_modify(struct nb_cb_modify_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_path *pn;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_ABORT:
 	case NB_EV_PREPARE:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		pn = nb_running_get_entry(args->dnode, NULL, true);
 		pn->tag = yang_dnode_get_uint32(args->dnode, NULL);
 		static_install_path(pn);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -138,12 +157,14 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 {
 	const struct lyd_node *pn_dnode;
 	struct nexthop_iter iter;
+	const char *ifname;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_path *pn;
 	struct ipaddr ipaddr;
 	struct static_nexthop *nh;
 	enum static_nh_type nh_type;
-	const char *ifname;
 	const char *nh_vrf;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
@@ -176,6 +197,7 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		yang_dnode_get_ip(&ipaddr, args->dnode, "./gateway");
 		nh_type = yang_dnode_get_enum(args->dnode, "./nh-type");
@@ -193,6 +215,9 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 					0);
 		nb_running_set_entry(args->dnode, nh);
 		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 
 	return NB_OK;
@@ -200,16 +225,22 @@ static bool static_nexthop_create(struct nb_cb_create_args *args)
 
 static bool static_nexthop_destroy(struct nb_cb_destroy_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_nexthop *nh;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		nh = nb_running_unset_entry(args->dnode);
 		static_delete_nexthop(nh);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -218,22 +249,27 @@ static bool static_nexthop_destroy(struct nb_cb_destroy_args *args)
 
 static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_nexthop *nh;
 	uint32_t pos;
 	uint8_t index;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 		if (!mpls_enabled) {
 			snprintf(
 				args->errmsg, args->errmsg_len,
 				"%% MPLS not turned on in kernel ignoring static route");
 			return NB_ERR_VALIDATION;
 		}
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 		break;
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
 		pos = yang_get_list_pos(args->dnode);
@@ -247,6 +283,9 @@ static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 		nh->snh_label.label[index] = 0;
 		nh->snh_label.num_labels++;
 		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 
 	return NB_OK;
@@ -255,15 +294,18 @@ static int nexthop_mpls_label_stack_entry_create(struct nb_cb_create_args *args)
 static int
 nexthop_mpls_label_stack_entry_destroy(struct nb_cb_destroy_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_nexthop *nh;
 	uint32_t pos;
 	uint8_t index;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
 		pos = yang_get_list_pos(args->dnode);
@@ -276,11 +318,15 @@ nexthop_mpls_label_stack_entry_destroy(struct nb_cb_destroy_args *args)
 		nh->snh_label.label[index] = 0;
 		nh->snh_label.num_labels--;
 		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 
 	return NB_OK;
 }
 
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 static int static_nexthop_mpls_label_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
@@ -300,10 +346,13 @@ static int static_nexthop_mpls_label_modify(struct nb_cb_modify_args *args)
 
 	return NB_OK;
 }
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_nexthop *nh;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 	enum static_nh_type nh_type;
 
 	switch (args->event) {
@@ -320,15 +369,20 @@ static int static_nexthop_onlink_modify(struct nb_cb_modify_args *args)
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
 		nh->onlink = yang_dnode_get_bool(args->dnode, NULL);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
 	return NB_OK;
 }
 
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 static int static_nexthop_color_modify(struct nb_cb_modify_args *args)
 {
 	struct static_nexthop *nh;
@@ -348,10 +402,13 @@ static int static_nexthop_color_destroy(struct nb_cb_destroy_args *args)
 
 	return NB_OK;
 }
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 static int static_nexthop_bh_type_modify(struct nb_cb_modify_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_nexthop *nh;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 	enum static_nh_type nh_type;
 
 	switch (args->event) {
@@ -366,15 +423,20 @@ static int static_nexthop_bh_type_modify(struct nb_cb_modify_args *args)
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		nh = nb_running_get_entry(args->dnode, NULL, true);
 		nh->bh_type = yang_dnode_get_enum(args->dnode, NULL);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
 	return NB_OK;
 }
 
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_apply_finish(
 	struct nb_cb_apply_finish_args *args)
 {
@@ -394,6 +456,7 @@ void routing_control_plane_protocols_control_plane_protocol_staticd_route_list_s
 
 	static_install_nexthop(nh);
 }
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_path_list_frr_nexthops_nexthop_pre_validate(
 	struct nb_cb_pre_validate_args *args)
@@ -433,10 +496,12 @@ int routing_control_plane_protocols_name_validate(
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_create(
 	struct nb_cb_create_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
+	const struct lyd_node *vrf_dnode;
 	struct vrf *vrf;
 	struct static_vrf *s_vrf;
 	struct route_node *rn;
-	const struct lyd_node *vrf_dnode;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 	struct prefix prefix;
 	const char *afi_safi;
 	afi_t prefix_afi;
@@ -460,6 +525,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_cr
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		vrf_dnode = yang_dnode_get_parent(args->dnode,
 						  "control-plane-protocol");
@@ -478,6 +544,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_cr
 				yang_dnode_get_string(args->dnode, "./prefix"));
 		nb_running_set_entry(args->dnode, rn);
 		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 	return NB_OK;
 }
@@ -485,16 +554,22 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_cr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_destroy(
 	struct nb_cb_destroy_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct route_node *rn;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		rn = nb_running_unset_entry(args->dnode);
 		static_del_route(rn);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -574,10 +649,14 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_color_modify(args) != NB_OK)
 			return NB_ERR;
 
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -591,9 +670,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_color_destroy(args) != NB_OK)
 			return NB_ERR;
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -627,9 +710,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_mpls_label_modify(args) != NB_OK)
 			return NB_ERR;
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -647,7 +734,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -664,7 +755,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -678,7 +773,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -696,7 +795,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -710,7 +813,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -724,6 +831,7 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_pa
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_create(
 	struct nb_cb_create_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct static_vrf *s_vrf;
 	struct route_node *rn;
 	struct route_node *src_rn;
@@ -731,12 +839,14 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	struct stable_info *info;
 	afi_t afi;
 	safi_t safi = SAFI_UNICAST;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		rn = nb_running_get_entry(args->dnode, NULL, true);
 		info = route_table_get_info(rn->table);
@@ -747,6 +857,9 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 			static_add_route(afi, safi, &rn->p, &src_prefix, s_vrf);
 		nb_running_set_entry(args->dnode, src_rn);
 		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
+		break;
 	}
 	return NB_OK;
 }
@@ -754,16 +867,22 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_src_list_destroy(
 	struct nb_cb_destroy_args *args)
 {
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	struct route_node *src_rn;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
 
 	switch (args->event) {
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		src_rn = nb_running_unset_entry(args->dnode);
 		static_del_route(src_rn);
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -844,10 +963,14 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_color_modify(args) != NB_OK)
 			return NB_ERR;
 
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -862,9 +985,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_color_destroy(args) != NB_OK)
 			return NB_ERR;
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -898,9 +1025,13 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
 		break;
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
 		if (static_nexthop_mpls_label_modify(args) != NB_OK)
 			return NB_ERR;
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -918,7 +1049,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 	return NB_OK;
@@ -935,7 +1070,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -949,7 +1088,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -967,7 +1110,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 
@@ -981,7 +1128,11 @@ int routing_control_plane_protocols_control_plane_protocol_staticd_route_list_sr
 	case NB_EV_VALIDATE:
 	case NB_EV_PREPARE:
 	case NB_EV_ABORT:
+#ifndef INCLUDE_MGMTD_VALIDATE_ONLY
 	case NB_EV_APPLY:
+		break;
+#endif /* ifndef INCLUDE_MGMTD_VALIDATE_ONLY */
+	default:
 		break;
 	}
 

--- a/staticd/static_routes.c
+++ b/staticd/static_routes.c
@@ -773,30 +773,6 @@ void static_ifindex_update(struct interface *ifp, bool up)
 	static_ifindex_update_af(ifp, up, AFI_IP6, SAFI_MULTICAST);
 }
 
-void static_get_nh_type(enum static_nh_type stype, char *type, size_t size)
-{
-	switch (stype) {
-	case STATIC_IFNAME:
-		strlcpy(type, "ifindex", size);
-		break;
-	case STATIC_IPV4_GATEWAY:
-		strlcpy(type, "ip4", size);
-		break;
-	case STATIC_IPV4_GATEWAY_IFNAME:
-		strlcpy(type, "ip4-ifindex", size);
-		break;
-	case STATIC_BLACKHOLE:
-		strlcpy(type, "blackhole", size);
-		break;
-	case STATIC_IPV6_GATEWAY:
-		strlcpy(type, "ip6", size);
-		break;
-	case STATIC_IPV6_GATEWAY_IFNAME:
-		strlcpy(type, "ip6-ifindex", size);
-		break;
-	};
-}
-
 struct stable_info *static_get_stable_info(struct route_node *rn)
 {
 	struct route_table *table;

--- a/staticd/static_routes.h
+++ b/staticd/static_routes.h
@@ -162,6 +162,31 @@ static_route_info_from_rnode(struct route_node *rn)
 	return (struct static_route_info *)(rn->info);
 }
 
+static inline void static_get_nh_type(enum static_nh_type stype, char *type,
+				      size_t size)
+{
+	switch (stype) {
+	case STATIC_IFNAME:
+		strlcpy(type, "ifindex", size);
+		break;
+	case STATIC_IPV4_GATEWAY:
+		strlcpy(type, "ip4", size);
+		break;
+	case STATIC_IPV4_GATEWAY_IFNAME:
+		strlcpy(type, "ip4-ifindex", size);
+		break;
+	case STATIC_BLACKHOLE:
+		strlcpy(type, "blackhole", size);
+		break;
+	case STATIC_IPV6_GATEWAY:
+		strlcpy(type, "ip6", size);
+		break;
+	case STATIC_IPV6_GATEWAY_IFNAME:
+		strlcpy(type, "ip6-ifindex", size);
+		break;
+	};
+}
+
 extern bool mpls_enabled;
 
 extern struct zebra_privs_t static_privs;
@@ -194,8 +219,6 @@ extern struct static_path *static_add_path(struct route_node *rn,
 					   uint32_t table_id, uint8_t distance);
 extern void static_del_path(struct static_path *pn);
 
-extern void static_get_nh_type(enum static_nh_type stype, char *type,
-			       size_t size);
 extern bool static_add_nexthop_validate(const char *nh_vrf_name,
 					enum static_nh_type type,
 					struct ipaddr *ipaddr);

--- a/staticd/static_vty.h
+++ b/staticd/static_vty.h
@@ -23,6 +23,11 @@
 extern "C" {
 #endif
 
+#ifndef INCLUDE_MGMTD_CMDDEFS_ONLY
+void static_mgmt_init(struct thread_master *master);
+void static_mgmt_destroy(void);
+#endif /* ifndef INCLUDE_MGMTD_CMDDEFS_ONLY */
+
 void static_cli_show(struct vty *vty, struct lyd_node *dnode,
 		     bool show_defaults);
 void static_cli_show_end(struct vty *vty, struct lyd_node *dnode);

--- a/vtysh/extract.pl.in
+++ b/vtysh/extract.pl.in
@@ -72,6 +72,12 @@ sub scan_file {
             $hidden = 0;
         }
 
+        if ($defun_or_alias =~ /_YANG/) {
+            $yang = 1;
+        } else {
+            $yang = 0;
+        }
+
         $defun_array[0] = '';
 
         # Actual input command string.
@@ -146,6 +152,18 @@ sub scan_file {
         else {
            ($protocol) = ($file =~ /^(?:.*\/)?([a-z0-9]+)\/[a-zA-Z0-9_\-]+\.c$/);
            $protocol = "VTYSH_" . uc $protocol;
+        }
+
+        if ($yang) {
+            #
+            # MGMTD-NOTE: Slowly bit-by-bit we will move all components and
+            # their command handling to MGMTD daemon. For now following
+            # component commands will be handled by the new MGMTD daemon.
+            #
+            if ($protocol =~ /VTYSH_STATICD$/) {
+                # Move all Static YANG commands to new MGMTD daemon
+                $protocol = "VTYSH_MGMTD";
+            }
         }
 
         # Append _vtysh to structure then build DEFUN again


### PR DESCRIPTION
This commmit indroduces Staticd as a backend client for the MGMTd
framework. All the static commands will be diverted to the MGMTd
daemons and will use the Transactional model to make changes to the
internal state. Similar mechanism can be used by other daemon to use
the MGMT framework in the future.

This commit includes the following functionalities in the changeset:
1. Diverts all the staticd (config only) commands to MGMTd.
2. Adds staticd as a backend client to use the MGMT framework.
3. Modify the staticd NB config handlers so that they can be compiled
   into a library and loaded in the MGMTd process context.

Co-author: Pushpasis Sarkar spushpasis@vmware.com
Co-author: Abhinay Ramesh rabhinay@vmware.com
Co-author: Ujwal P ujwalp@vmware.com
Signed-off-by: Yash Ranjan ranjany@vmware.com